### PR TITLE
Cancel one order by order_id, instead of all

### DIFF
--- a/lib/ex_gdax.ex
+++ b/lib/ex_gdax.ex
@@ -222,10 +222,11 @@ defmodule ExGdax do
 
   ## Examples
 
-      iex> ExGdax.cancel_orders()
+      iex> ExGdax.cancel_orders(params)
       {:ok, ["XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"]}
   """
   defdelegate cancel_orders, to: ExGdax.Private, as: :cancel_orders
+  defdelegate cancel_orders(order_id), to: ExGdax.Private, as: :cancel_orders
 
   @doc """
   List open orders.

--- a/lib/ex_gdax/private.ex
+++ b/lib/ex_gdax/private.ex
@@ -28,6 +28,10 @@ defmodule ExGdax.Private do
     delete("/orders")
   end
 
+  def cancel_orders(order_id) do
+    delete("/orders/#{order_id}")
+  end
+
   def list_orders(params \\ %{}) do
     get("/orders", params)
   end


### PR DESCRIPTION
With this small PR you can delete all orders or delete an order by order_id.