### PR TITLE
Update default url to coinbase pro

### DIFF
--- a/lib/ex_gdax/config.ex
+++ b/lib/ex_gdax/config.ex
@@ -2,7 +2,7 @@ defmodule ExGdax.Config do
   @moduledoc """
   Stores configuration variables for signing authenticated requests to GDAX.
   """
-  @default_api_url "https://api.gdax.com"
+  @default_api_url "https://api.pro.coinbase.com"
   @enforce_keys [:api_key, :api_secret, :api_passphrase]
   defstruct [:api_key, :api_secret, :api_passphrase, api_url: @default_api_url]
 


### PR DESCRIPTION
GDAX is now deprecated https://docs.gdax.com/

<img width="535" alt="screen shot 2018-09-09 at 3 52 14 pm" src="https://user-images.githubusercontent.com/680789/45269782-721dca00-b448-11e8-9a31-4dc0b553dfd0.png">
