### PR TITLE
Fix invalid signature on authenticated GET request

### DIFF
--- a/lib/ex_gdax/api.ex
+++ b/lib/ex_gdax/api.ex
@@ -6,11 +6,11 @@ defmodule ExGdax.Api do
 
   def get(path, params \\ %{}, config \\ nil) do
     config = Config.config_or_env_config(config)
+    qs = query_string(path, params)
 
-    path
-    |> query_string(params)
+    qs
     |> url(config)
-    |> HTTPoison.get(headers("GET", path, %{}, config))
+    |> HTTPoison.get(headers("GET", qs, %{}, config))
     |> parse_response()
   end
 


### PR DESCRIPTION
The signature for GET requests must be made with the path+arg string
and not just the path. Prior to this patch authenticated GET requests
would fail with an "invalid signature" error:

iex(19)> ExGdax.list_fills(%{product_id: "BTC-EUR"})
{:error, "invalid signature", 400}

This patch ensures that the signature is created with the query string,
not just the URI path. `list_fills`, as above, then returns data.